### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,11 +13,17 @@ jobs:
           mkdir -p ~/.ssh
           echo "${GIT_DEPLOY_KEY}" > ~/.ssh/id_rsa
           chmod 0600 ~/.ssh/id_rsa
+
+          git clone git@github.com:movableink/pr-clubhouse-lint-action.git
+          cd pr-clubhouse-lint-action
+
           git checkout release
           git pull --rebase
           git merge master
+
           rm -Rf node_modules
           npm install --production
+
           git add .
           git commit -m 'release'
           # git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ jobs:
           rm -Rf node_modules
           npm install --production
 
+          du -h --max-depth=1 .
+
           git add .
           git commit -m 'release'
           # git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,13 @@ jobs:
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
         run: |
+          mkdir -p ~/.ssh
           echo "${GIT_DEPLOY_KEY}" > ~/.ssh/id_rsa
+          chmod 0600 ~/.ssh/id_rsa
           git checkout release
           git pull --rebase
-          rm -Rf node_modules
           git merge master
+          rm -Rf node_modules
           npm install --production
           git add .
           git commit -m 'release'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,9 @@ jobs:
           echo "${GIT_DEPLOY_KEY}" > ~/.ssh/id_rsa
           chmod 400 ~/.ssh/id_rsa
 
+          git config --global user.email "release@movableink.com"
+          git config --global user.name "Movable Ink Release"
+
           git clone git@github.com:movableink/pr-clubhouse-lint-action.git
           cd pr-clubhouse-lint-action
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,5 +31,5 @@ jobs:
           du -h --max-depth=1 .
 
           git add .
-          git commit -m 'release'
+          git commit -m "vendored release for $(git rev-parse master)"
           # git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
         run: |
-          echo "${GIT_DEPLOY_KEY}" > /root/.ssh/id_rsa
+          echo "${GIT_DEPLOY_KEY}" > ~/.ssh/id_rsa
           git checkout release
           git pull --rebase
           rm -Rf node_modules

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   release:
@@ -32,4 +35,4 @@ jobs:
 
           git add .
           git commit -m "vendored release for $(git rev-parse master)"
-          # git push
+          git push origin release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Release
+on: [push]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge release branch
+        env:
+          GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
+        run: |
+          echo "${GIT_DEPLOY_KEY}" > /root/.ssh/id_rsa
+          git checkout release
+          git pull --rebase
+          rm -Rf node_modules
+          git merge master
+          npm install --production
+          git add .
+          git commit -m 'release'
+          # git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,9 @@ jobs:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
         run: |
           mkdir -p ~/.ssh
+          ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
           echo "${GIT_DEPLOY_KEY}" > ~/.ssh/id_rsa
-          chmod 0600 ~/.ssh/id_rsa
+          chmod 400 ~/.ssh/id_rsa
 
           git clone git@github.com:movableink/pr-clubhouse-lint-action.git
           cd pr-clubhouse-lint-action


### PR DESCRIPTION
This adds a Github Action to update the `release` branch whenever a new commit is merged to `master`. We have a separate `release` branch because there, we need to vendor `node_modules`, but only with production dependencies.