### PR TITLE
[Chore] Renaming Clubhouse to Shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# pr-clubhouse-lint-action
+# pr-shortcut-lint-action
 
-A GitHub Action that verifies your pull request contains a reference to a Clubhouse card. If your Clubhouse card number is 1234, this will check for `[ch1234]` or `ch1234/` in:
+A GitHub Action that verifies your pull request contains a reference to a Shortcut card. If your Shortcut card number is 1234, this will check for `[ch1234]` or `ch1234/` in:
 
 * The pull request title
 * The pull request body
@@ -12,7 +12,7 @@ A GitHub Action that verifies your pull request contains a reference to a Clubho
 Add `.github/workflows/lint.yaml` with the following:
 
 ```yaml
-name: Clubhouse
+name: Shortcut
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: Clubhouse PR Lint
-description: Checks pull requests to ensure they have Clubhouse links
+name: Shortcut PR Lint
+description: Checks pull requests to ensure they have Shortcut links
 author: Movable Ink
 runs:
   using: "node12"

--- a/lib/action.js
+++ b/lib/action.js
@@ -1,11 +1,13 @@
 const core = require('@actions/core');
 
-// Matches [ch49555] and ch49555/branch-name
-const clubhouseRegex = /(\[ch\d+\])|(ch\d+\/)/;
+// Matches
+// [ch49555] or [sc-49555] or [sc49555] ticket reference
+// ch49555/branch-name or sc49555/branch-name or sc-49555/branch-name
+const shortcutRegex = /(\[ch\d+\])|(ch\d+\/)|(\[sc\d+\])|(sc\d+\/)|(\[sc-\d+\])|(sc-\d+\/)/;
 
 // We need to be able to identify old checks to neutralize them,
 // unfortunately the only way is to name them with one of these:
-const jobNames = ['Clubhouse', 'Check for story ID'];
+const jobNames = ['Shortcut', 'Check for story ID'];
 
 module.exports = async function(context, api) {
   const { repository, pull_request } = context.payload;
@@ -28,12 +30,12 @@ module.exports = async function(context, api) {
   toSearch.push(`Branch name: ${headBranch}`);
 
   const passed = toSearch.some(line => {
-    const linePassed = !!line.match(clubhouseRegex);
+    const linePassed = !!line.match(shortcutRegex);
     console.log(`Searching ${line}...${linePassed}`);
     return linePassed;
   });
 
-  console.log(`Passed clubhouse number check: ${passed}`);
+  console.log(`Passed shortcut number check: ${passed}`);
 
   if (!passed) {
     core.setFailed('PR Linting Failed');
@@ -45,8 +47,8 @@ module.exports = async function(context, api) {
     const checkList = await api.checks.listForRef(repoInfo);
     const { check_runs } = checkList.data;
 
-    const clubhouseChecks = check_runs.filter(r => jobNames.includes(r.name));
-    const completedChecks = clubhouseChecks.filter(r => r.status === 'completed');
+    const shortcutChecks = check_runs.filter(r => jobNames.includes(r.name));
+    const completedChecks = shortcutChecks.filter(r => r.status === 'completed');
 
     for (let check of completedChecks) {
       console.log(`Updating ${check.id} check to neutral status`);

--- a/lib/action.test.js
+++ b/lib/action.test.js
@@ -14,35 +14,58 @@ describe('pr-lint-action', () => {
     body: 'a great pull request',
     ref_name: 'no-ticket-in-me'
   };
-  const good_title_and_branch = {
-    title: '[ch39234] a good PR title',
-    body: 'a great pull request',
-    ref_name: 'ch39234/a_good_branch'
+
+  const clubhouse = {
+    good_title_and_branch: {
+      title: '[ch39234] a good PR title',
+      body: 'a great pull request',
+      ref_name: 'ch39234/a_good_branch'
+    },
+    bad_title_and_good_branch: {
+      title: 'no ticket in me',
+      ref_name: 'bug/ch1234/a_good_branch'
+    },
+    good_body: {
+      title: 'no ticket in me',
+      body: '[ch39234] a great pull request',
+      ref_name: 'fix_things'
+    }
   };
-  const good_title_and_bad_branch = {
-    title: '[ch39494] a good PR title',
-    body: 'a great pull request',
-    ref_name: 'fix_things'
+
+  const shortcut = {
+    good_title_and_branch: {
+      title: '[sc9234] a good PR title',
+      body: 'a great pull request',
+      ref_name: 'ch39234/a_good_branch'
+    },
+    bad_title_and_good_branch: {
+      title: 'no ticket in me',
+      ref_name: 'bug/sc1234/a_good_branch'
+    },
+    good_body: {
+      title: 'no ticket in me',
+      body: '[sc39234] a great pull request',
+      ref_name: 'fix_things'
+    },
+    dashorized: {
+      good_title_and_branch: {
+        title: '[sc-9234] a good PR title',
+        body: 'a great pull request',
+        ref_name: 'ch39234/a_good_branch'
+      },
+      bad_title_and_good_branch: {
+        title: 'no ticket in me',
+        ref_name: 'bug/sc-1234/a_good_branch'
+      },
+      good_body: {
+        title: 'no ticket in me',
+        body: '[sc-39234] a great pull request',
+        ref_name: 'fix_things'
+      }
+    }
   };
-  const bad_title_and_good_branch = {
-    title: 'no ticket in me',
-    ref_name: 'bug/ch1234/a_good_branch'
-  };
-  const good_body = {
-    title: 'no ticket in me',
-    body: '[ch39234] a great pull request',
-    ref_name: 'fix_things'
-  };
-  const good_commits = [
-    { commit: { message: '[ch1234] Commit 1' } },
-    { commit: { message: 'Commit 2' } },
-    { commit: { message: 'Commit 3' } }
-  ];
-  const bad_commits = [
-    { commit: { message: 'Commit 1' } },
-    { commit: { message: 'Commit 2' } },
-    { commit: { message: 'Commit 3' } }
-  ];
+
+
 
   beforeEach(() => {
     console.log = jest.fn();
@@ -66,31 +89,91 @@ describe('pr-lint-action', () => {
       expect.assertions(1);
     });
 
-    it('passes if branch matches', async () => {
-      context.payload = pullRequestOpenedFixture(bad_title_and_good_branch);
+    describe('clubhouse', () => {
+      it('passes if branch matches', async () => {
+        context.payload = pullRequestOpenedFixture(clubhouse.bad_title_and_good_branch);
 
-      await action(context, api);
-      expect(console.log).toHaveBeenCalledWith('Passed clubhouse number check: true');
-      expect(core.setFailed).not.toHaveBeenCalled();
-      expect.assertions(2);
+        await action(context, api);
+        expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+        expect(core.setFailed).not.toHaveBeenCalled();
+        expect.assertions(2);
+      });
+
+      it('passes if title matches', async () => {
+        context.payload = pullRequestOpenedFixture(clubhouse.good_title_and_branch);
+
+        await action(context, api);
+        expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+        expect(core.setFailed).not.toHaveBeenCalled();
+        expect.assertions(2);
+      });
+
+      it('passes if body matches', async () => {
+        context.payload = pullRequestOpenedFixture(clubhouse.good_body);
+
+        await action(context, api);
+        expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+        expect(core.setFailed).not.toHaveBeenCalled();
+        expect.assertions(2);
+      });
     });
 
-    it('passes if title matches', async () => {
-      context.payload = pullRequestOpenedFixture(good_title_and_branch);
+    describe('shortcut', () => {
+      it('passes if branch matches', async () => {
+        context.payload = pullRequestOpenedFixture(shortcut.bad_title_and_good_branch);
 
-      await action(context, api);
-      expect(console.log).toHaveBeenCalledWith('Passed clubhouse number check: true');
-      expect(core.setFailed).not.toHaveBeenCalled();
-      expect.assertions(2);
-    });
+        await action(context, api);
+        expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+        expect(core.setFailed).not.toHaveBeenCalled();
+        expect.assertions(2);
+      });
 
-    it('passes if body matches', async () => {
-      context.payload = pullRequestOpenedFixture(good_body);
+      it('passes if title matches', async () => {
+        context.payload = pullRequestOpenedFixture(shortcut.good_title_and_branch);
 
-      await action(context, api);
-      expect(console.log).toHaveBeenCalledWith('Passed clubhouse number check: true');
-      expect(core.setFailed).not.toHaveBeenCalled();
-      expect.assertions(2);
+        await action(context, api);
+        expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+        expect(core.setFailed).not.toHaveBeenCalled();
+        expect.assertions(2);
+      });
+
+      it('passes if body matches', async () => {
+        context.payload = pullRequestOpenedFixture(shortcut.good_body);
+
+        await action(context, api);
+        expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+        expect(core.setFailed).not.toHaveBeenCalled();
+        expect.assertions(2);
+      });
+
+      describe('dashorized', () => {
+        it('passes if branch matches', async () => {
+          context.payload = pullRequestOpenedFixture(shortcut.dashorized.bad_title_and_good_branch);
+
+          await action(context, api);
+          expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+          expect(core.setFailed).not.toHaveBeenCalled();
+          expect.assertions(2);
+        });
+
+        it('passes if title matches', async () => {
+          context.payload = pullRequestOpenedFixture(shortcut.dashorized.good_title_and_branch);
+
+          await action(context, api);
+          expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+          expect(core.setFailed).not.toHaveBeenCalled();
+          expect.assertions(2);
+        });
+
+        it('passes if body matches', async () => {
+          context.payload = pullRequestOpenedFixture(shortcut.dashorized.good_body);
+
+          await action(context, api);
+          expect(console.log).toHaveBeenCalledWith('Passed shortcut number check: true');
+          expect(core.setFailed).not.toHaveBeenCalled();
+          expect.assertions(2);
+        });
+      })
     });
   });
 
@@ -103,19 +186,19 @@ describe('pr-lint-action', () => {
               {
                 // this is us, ignore
                 id: 1,
-                name: 'Clubhouse',
+                name: 'Shortcut',
                 status: 'in_progress',
                 conclusion: 'neutral'
               },
               {
                 id: 2,
-                name: 'Clubhouse',
+                name: 'Shortcut',
                 status: 'completed',
                 conclusion: 'failure'
               },
               {
                 id: 3,
-                name: 'Clubhouse',
+                name: 'Shortcut',
                 status: 'completed',
                 conclusion: 'failure'
               },
@@ -133,29 +216,84 @@ describe('pr-lint-action', () => {
       };
     });
 
-    it('updates the previous failed check to neutral', async () => {
-      context.payload = pullRequestOpenedFixture(good_body);
+    describe('clubhouse', ()=> {
+      it('updates the previous failed check to neutral', async () => {
+        context.payload = pullRequestOpenedFixture(clubhouse.good_body);
 
-      await action(context, api);
+        await action(context, api);
 
-      expect(api.checks.update).toHaveBeenCalledTimes(2);
+        expect(api.checks.update).toHaveBeenCalledTimes(2);
 
-      expect(api.checks.update).toHaveBeenNthCalledWith(1, {
-        check_run_id: 2,
-        owner: 'movableink',
-        repo: 'pr-clubhouse-lint-action-test',
-        ref: 'fix_things',
-        conclusion: 'neutral'
-      });
+        expect(api.checks.update).toHaveBeenNthCalledWith(1, {
+          check_run_id: 2,
+          owner: 'movableink',
+          repo: 'pr-shortcut-lint-action-test',
+          ref: 'fix_things',
+          conclusion: 'neutral'
+        });
 
-      expect(api.checks.update).toHaveBeenNthCalledWith(2, {
-        check_run_id: 3,
-        owner: 'movableink',
-        repo: 'pr-clubhouse-lint-action-test',
-        ref: 'fix_things',
-        conclusion: 'neutral'
+        expect(api.checks.update).toHaveBeenNthCalledWith(2, {
+          check_run_id: 3,
+          owner: 'movableink',
+          repo: 'pr-shortcut-lint-action-test',
+          ref: 'fix_things',
+          conclusion: 'neutral'
+        });
       });
     });
+
+    describe('shortcut', ()=> {
+      it('updates the previous failed check to neutral', async () => {
+        context.payload = pullRequestOpenedFixture(shortcut.good_body);
+
+        await action(context, api);
+
+        expect(api.checks.update).toHaveBeenCalledTimes(2);
+
+        expect(api.checks.update).toHaveBeenNthCalledWith(1, {
+          check_run_id: 2,
+          owner: 'movableink',
+          repo: 'pr-shortcut-lint-action-test',
+          ref: 'fix_things',
+          conclusion: 'neutral'
+        });
+
+        expect(api.checks.update).toHaveBeenNthCalledWith(2, {
+          check_run_id: 3,
+          owner: 'movableink',
+          repo: 'pr-shortcut-lint-action-test',
+          ref: 'fix_things',
+          conclusion: 'neutral'
+        });
+      });
+
+      describe('dashorized', () => {
+        it('updates the previous failed check to neutral', async () => {
+          context.payload = pullRequestOpenedFixture(shortcut.dashorized.good_body);
+
+          await action(context, api);
+
+          expect(api.checks.update).toHaveBeenCalledTimes(2);
+
+          expect(api.checks.update).toHaveBeenNthCalledWith(1, {
+            check_run_id: 2,
+            owner: 'movableink',
+            repo: 'pr-shortcut-lint-action-test',
+            ref: 'fix_things',
+            conclusion: 'neutral'
+          });
+
+          expect(api.checks.update).toHaveBeenNthCalledWith(2, {
+            check_run_id: 3,
+            owner: 'movableink',
+            repo: 'pr-shortcut-lint-action-test',
+            ref: 'fix_things',
+            conclusion: 'neutral'
+          });
+        });
+      })
+    });
+
   });
 });
 
@@ -170,7 +308,7 @@ function pullRequestOpenedFixture({ title, ref_name, body }) {
       }
     },
     repository: {
-      name: 'pr-clubhouse-lint-action-test',
+      name: 'pr-shortcut-lint-action-test',
       owner: {
         login: 'movableink'
       }


### PR DESCRIPTION
# Why
With the renaming of `clubhouse` to `shortcut` we need to update our ticket linter.

# How
After this PR has been merged we'll need to update the templates and links included in any other MI repo PR that is failing

https://github.com/movableink/front-end/pull/7089 is blocked by this PR.
